### PR TITLE
Enforce edition 2018 for rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+style_edition = "2018"


### PR DESCRIPTION
I was having a problem where running `rustfmt` outside of `cargo fmt` was not picking up the edition from `Cargo.toml`, at least when `apheleia` was calling `rustfmt`.  Explicitly tell `rustfmt` the code and style edition to use.